### PR TITLE
Changed cachePolicy of URLRequest.

### DIFF
--- a/ImagePipeline/Fetcher.swift
+++ b/ImagePipeline/Fetcher.swift
@@ -29,7 +29,7 @@ public final class Fetcher: Fetching {
         let queue = self.queue
         let taskExecutor = self.taskExecutor
 
-        let request = URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad)
+        let request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData)
         let task = session.dataTask(with: request) { (data, response, error) in
             queue.sync {
                 taskExecutor.removeTask(for: url)


### PR DESCRIPTION
# Why
In the current cache policy, the URLRequest's cache hits.

For ImagePipeline, cache should always use only `ImageCaching` or `DataCaching`.

Since `reloadIgnoringLocalAndRemoteCacheData` is not implemented, we specified `reloadIgnoringLocalCacheData`.

https://developer.apple.com/documentation/foundation/nsurlrequest/cachepolicy/reloadignoringlocalandremotecachedata