### PR TITLE
Fixed problem that imageView property of ImageViewReference becomes nil.

### DIFF
--- a/ImagePipeline/ImagePipeline.swift
+++ b/ImagePipeline/ImagePipeline.swift
@@ -129,7 +129,7 @@ public final class ImagePipeline {
 }
 
 private class ImageViewReference: Hashable {
-    weak var imageView: UIImageView?
+    var imageView: UIImageView?
     private let objectIdentifier: ObjectIdentifier
 
     init(_ imageView: UIImageView) {


### PR DESCRIPTION
# Why
Sometimes ImageView property of ImageViewReference becomes nil.

# Check
Since weak has been deleted, I checked whether memory leak due to circular reference occurs.

- [x] The deinit method of the ImageViewReference class is called.
- [x] The deinit method of the ImageViewController class is called. (When the application is in the background.)
- [x] The deinit method of ViewController using Imagepipeline will be called
