### PR TITLE
Fix type checking that doesn't end error

### DIFF
--- a/ImagePipeline/BlurFilter.swift
+++ b/ImagePipeline/BlurFilter.swift
@@ -71,7 +71,8 @@ public struct BlurFilter: ImageProcessing {
 
             if hasBlur {
                 let inputRadius = blurRadius * scale
-                var radius = UInt32(floor(inputRadius * 3 * sqrt(2 * CGFloat.pi) / 4 + 0.5))
+                let r = inputRadius * 3 * sqrt(2 * CGFloat.pi) / 4 + 0.5
+                var radius = UInt32(floor(r))
                 if (radius % 2 != 1) {
                     radius += 1; // force radius to be odd so that the three box-blur methodology works.
                 }


### PR DESCRIPTION
```
The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions
```